### PR TITLE
Feat: add attachments information to chat messages

### DIFF
--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -3,3 +3,5 @@ pytest
 pylint
 discord
 loguru
+pytest-mock
+pytest-asyncio

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -50,6 +50,13 @@ pluggy==1.3.0
 pylint==3.0.3
     # via -r requirements/dev.in
 pytest==7.4.3
+    # via
+    #   -r requirements/dev.in
+    #   pytest-asyncio
+    #   pytest-mock
+pytest-asyncio==0.23.2
+    # via -r requirements/dev.in
+pytest-mock==3.12.0
     # via -r requirements/dev.in
 tomlkit==0.12.3
     # via pylint

--- a/src/discord_bot/bot_main.py
+++ b/src/discord_bot/bot_main.py
@@ -12,6 +12,7 @@ from loguru import logger
 
 from ..chat_parser.chat_parser import MinecraftChatParser
 from ..rcon_sender.rcon import RconLocalDocker
+from .utillity import parse_message
 
 intents = discord.Intents.default()
 intents.message_content = True
@@ -151,10 +152,9 @@ async def on_message(message: discord.Message) -> None:
         return
     # Check if the message is from the desired channel
     if message.channel.id == CHANNEL_ID:
-        logger.info(f"<{message.author.display_name}>: {message.content}")
-        rcon.send_say_command(
-            f"<{message.author.display_name}>: {message.content}"
-        )
+        message_text = await parse_message(message)
+        logger.info(message_text)
+        rcon.send_say_command(message_text)
 
 
 def main():

--- a/src/discord_bot/utillity.py
+++ b/src/discord_bot/utillity.py
@@ -1,0 +1,130 @@
+"""Module for discord_bot utillity finctions."""
+from typing import Optional, Tuple
+
+import discord
+from loguru import logger
+
+
+async def parse_message_reference(
+    message: discord.Message,
+) -> Tuple[Optional[str], Optional[str]]:
+    """
+    Parse a Discord message reference and return the nickname
+    (or display name if server-nickname not exists), of the referenced
+    user and the content of the referenced message.
+
+    Args:
+        message (discord.Message): The incoming message.
+
+    Returns:
+        Tuple[Optional[str], Optional[str]]: A tuple containing the nickname
+            of the referenced user (or None) and the content of the referenced
+            message (or None).
+    """
+    ref_author_name, ref_content = None, None
+    if message.reference:
+        try:
+            ref_message = await message.channel.fetch_message(
+                message.reference.message_id
+            )
+
+        except discord.NotFound:
+            # Handle case where the referenced message is not found.
+            logger.warning("Message reference NotFound.")
+            return ref_author_name, ref_content
+
+        # Retrieve the user associated with the referenced message.
+        ref_message_users = await message.guild.query_members(
+            user_ids=[ref_message.author.id]
+        )
+
+        if ref_message_users:
+            # There should be only one user, so get the first item in the list.
+            ref_message_user = ref_message_users[0]
+            # Extract the nickname (or display name) of the referenced user.
+            ref_author_name = (
+                ref_message_user.nick or ref_message_user.display_name
+            )
+        # Get the content of the referenced message.
+        ref_content = ref_message.content
+    return ref_author_name, ref_content
+
+
+async def parse_formatted_message_reference(
+    message: discord.Message,
+    max_ref_message_length: int = 100,
+    max_nickname_length: int = 10,
+) -> str:
+    """
+    Parse a Discord message reference to create a formatted
+    message string.
+
+    Args:
+        message (discord.Message): The incoming message.
+        max_ref_message_length (int): Maximum length for the referenced
+            message.
+        max_nickname_length (int):  Maximum length for the referenced
+            message author.
+    Returns:
+        str: Formatted message string, including the referenced message
+            content.
+
+    Note:
+        If the referenced message is not found or an error occurs during
+        retrieval, an empty string will be returned.
+    """
+    ref_message = ""
+    if message.reference:
+        try:
+            ref_message = await message.channel.fetch_message(
+                message.reference.message_id
+            )
+
+        except discord.NotFound:
+            logger.warning("Message reference NotFound.")
+            return ""
+
+        ref_author_name, ref_content = await parse_message_reference(message)
+        if ref_content:
+            if not ref_author_name:
+                ref_author_name = "unknown"
+
+        if ref_content and len(ref_content) > max_ref_message_length:
+            ref_content = f"{ref_content[:max_ref_message_length]}..."
+        if ref_author_name and len(ref_author_name) > max_nickname_length:
+            ref_author_name = f"{ref_author_name[:max_nickname_length]}..."
+        ref_message = f"[{ref_author_name}: {ref_content}] -> "
+    return ref_message
+
+
+async def parse_message(
+    message: discord.Message,
+    max_ref_message_length: int = 100,
+    max_nickname_length: int = 10,
+) -> str:
+    """
+    Parse a Discord message to create a formatted message string.
+
+    Args:
+        message (discord.Message): The incoming message.
+        max_ref_message_length (int): Maximum length for the
+            referenced message.
+        max_nickname_length (int):  Maximum length for the referenced
+            message author.
+    Returns:
+        str: Formatted message string.
+    """
+    message_attachment = ""
+    if message.attachments:
+        message_attachment = "[картинка] "
+
+    message_reference = await parse_formatted_message_reference(
+        message,
+        max_ref_message_length=max_ref_message_length,
+        max_nickname_length=max_nickname_length,
+    )
+    message_text = (
+        f"<{message.author.display_name}>: "
+        f"{message_attachment}{message_reference}{message.content}"
+    )
+    return message_text


### PR DESCRIPTION
# Pull Request: Add Prefixes to Chat Messages
## Description:
Implement a feature to add prefixes to chat messages. The prefixes should include information about images and references in Discord. The specifics are outlined below:

## Prefixes:

### Image Information:

- Prefix: "[картинка] "
- Description: Identify messages that contain images.
### Reference Information:

- Prefix: "[Usrname: text ] -> "
- Description: If a reference exists, prefix the message with the username and text. If the message or username is too long, ensure trimming to keep the reference within the range of 100-120 symbols.
## Reasoning:
This feature aims to enhance the clarity of messages by providing additional context through prefixes. The trimming of long references ensures compatibility with Rcon output limitations.

## Testing:
Ensure comprehensive testing covering scenarios with images, references, and varying message lengths.
