### PR TITLE
Fix reference attachments

### DIFF
--- a/src/discord_bot/bot_main.py
+++ b/src/discord_bot/bot_main.py
@@ -40,7 +40,7 @@ async def send_heartbeat():
 
 
 @bot.event
-@logger.catch(reraise=True)
+@logger.catch()
 async def on_ready():
     """
     Event handler for when the bot has successfully connected to Discord.
@@ -76,7 +76,7 @@ async def on_ready():
 
 
 @bot.command(name="list")
-@logger.catch(reraise=True)
+@logger.catch()
 async def get_list_of_players(ctx: commands.Context) -> None:
     """
     Get the list of online players on the Minecraft server.
@@ -102,7 +102,7 @@ async def get_list_of_players(ctx: commands.Context) -> None:
 
 
 @bot.command(name="info")
-@logger.catch(reraise=True)
+@logger.catch()
 async def get_list_of_cammands(ctx: commands.Context) -> None:
     """
     Get the list of available commands.
@@ -117,7 +117,7 @@ async def get_list_of_cammands(ctx: commands.Context) -> None:
 
 
 @bot.event
-@logger.catch(reraise=True)
+@logger.catch()
 async def on_command_error(ctx: commands.Context, error: Any) -> None:
     """
     Handle errors that occur during command execution.
@@ -135,7 +135,7 @@ async def on_command_error(ctx: commands.Context, error: Any) -> None:
 
 
 @bot.event
-@logger.catch(reraise=True)
+@logger.catch()
 async def on_message(message: discord.Message) -> None:
     """
     Event handler for processing incoming messages.


### PR DESCRIPTION
# Pull Request: Fix Reference Attachments
## Desctiption:
Information about images does not get pasted into referenced messages: "<JohnDoe>: [картинка] [JohnDoe: [картинка] test reference message] -> Message text"

## Tasks:
- Fix the attachments issue.
- Remove the parameter reraise=True for all @logger.catch calls. (This is needed to improve stability of bot.)
